### PR TITLE
Fix normalize_url to preserve queries and fragments

### DIFF
--- a/src/llmseo/utils.py
+++ b/src/llmseo/utils.py
@@ -2,15 +2,36 @@ from __future__ import annotations
 
 import re
 import math
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse, urljoin, urlsplit, urlunsplit
+
+
+_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 
 
 def normalize_url(url: str) -> str:
-    parsed = urlparse(url)
-    scheme = parsed.scheme or "https"
-    netloc = parsed.netloc or parsed.path
-    path = parsed.path if parsed.netloc else ""
-    return f"{scheme}://{netloc}{path or '/'}"
+    url = (url or "").strip()
+    if not url:
+        raise ValueError("URL cannot be empty")
+
+    if url.startswith("//"):
+        url = "https:" + url
+    elif not _SCHEME_RE.match(url):
+        url = "https://" + url.lstrip("/")
+
+    parts = urlsplit(url)
+    scheme = parts.scheme or "https"
+    netloc = parts.netloc
+    path = parts.path
+
+    if not netloc and parts.path:
+        netloc = parts.path
+        path = ""
+
+    if not netloc:
+        raise ValueError(f"URL must include a host: {url!r}")
+
+    path = path or "/"
+    return urlunsplit((scheme, netloc, path, parts.query, parts.fragment))
 
 
 def is_same_origin(base: str, other: str) -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+
+from llmseo.utils import normalize_url
+
+
+@pytest.mark.parametrize(
+    "input_url,expected",
+    [
+        ("https://example.com/path?foo=1", "https://example.com/path?foo=1"),
+        ("example.com/path?foo=1", "https://example.com/path?foo=1"),
+        ("https://example.com?foo=1", "https://example.com/?foo=1"),
+        ("https://example.com/path?foo=1#frag", "https://example.com/path?foo=1#frag"),
+    ],
+)
+def test_normalize_url_preserves_important_parts(input_url, expected):
+    assert normalize_url(input_url) == expected
+
+
+def test_normalize_url_rejects_empty_values():
+    with pytest.raises(ValueError):
+        normalize_url("   ")


### PR DESCRIPTION
## Summary
- ensure normalize_url retains query strings, fragments, and handles schemeless URLs correctly
- validate normalize_url input and avoid constructing malformed hosts
- add pytest coverage for normalize_url edge cases

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d21b6a2ca48320941daa32676a1e6b