### PR TITLE
Fix URL normalization edge cases

### DIFF
--- a/src/llmseo/cli.py
+++ b/src/llmseo/cli.py
@@ -26,7 +26,10 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    site = audit_url(args.url, max_pages=args.max_pages)
+    try:
+        site = audit_url(args.url, max_pages=args.max_pages)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     # Generate llm.txt draft
     llm_txt = generate_llm_txt(site.base_url, sitemaps=site.sitemaps)

--- a/src/llmseo/web.py
+++ b/src/llmseo/web.py
@@ -264,7 +264,10 @@ def create_app() -> Flask:
                 max_pages = int(payload.get("max_pages", 1))
             except (TypeError, ValueError):
                 max_pages = 1
-            site = audit_url(url, max_pages=max_pages)
+            try:
+                site = audit_url(url, max_pages=max_pages)
+            except ValueError as exc:
+                return jsonify({"error": str(exc)}), 400
             llm_txt = generate_llm_txt(site.base_url, sitemaps=site.sitemaps)
             pages_payload = [
                 {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import unittest
+
+from llmseo.utils import normalize_url
+
+
+class NormalizeUrlTests(unittest.TestCase):
+    def test_adds_scheme_and_trailing_slash_for_domain(self) -> None:
+        self.assertEqual(normalize_url("example.com"), "https://example.com/")
+
+    def test_preserves_path_when_scheme_missing(self) -> None:
+        self.assertEqual(normalize_url("example.com/path"), "https://example.com/path")
+
+    def test_keeps_query_parameters(self) -> None:
+        self.assertEqual(normalize_url("example.com/path?x=1"), "https://example.com/path?x=1")
+
+    def test_handles_localhost_with_port(self) -> None:
+        self.assertEqual(normalize_url("localhost:8000/foo"), "https://localhost:8000/foo")
+
+    def test_rejects_relative_paths(self) -> None:
+        with self.assertRaises(ValueError):
+            normalize_url("/just/a/path")
+
+    def test_rejects_blank_values(self) -> None:
+        with self.assertRaises(ValueError):
+            normalize_url("   ")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize user-supplied URLs so scheme-less paths retain their host and query while rejecting inputs without a host
- surface validation errors cleanly through the CLI and web API when URL normalization fails
- cover the revised behaviour with unit tests for typical and invalid URL inputs

## Testing
- PYTHONPATH=./src python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d34abe34508320976fef36cf010ae9